### PR TITLE
Add customer email field

### DIFF
--- a/desk/src/components/CommunicationArea.vue
+++ b/desk/src/components/CommunicationArea.vue
@@ -103,6 +103,10 @@ import { useShortcut } from "@/composables/shortcuts";
 import { showCommentBox, showEmailBox } from "@/pages/ticket/modalStates";
 import { ref, watch } from "vue";
 import { onClickOutside } from "@vueuse/core";
+import { inject } from "vue"
+import { TicketSymbol } from "@/types"
+
+const ticket = inject(TicketSymbol)
 
 const emit = defineEmits(["update"]);
 const content = defineModel("content");
@@ -149,14 +153,20 @@ function splitIfString(str: string | string[]) {
 }
 
 function replyToEmail(data: object) {
-  showEmailBox.value = true;
+  showEmailBox.value = true
+
+  const customerEmail = ticket?.value?.doc?.customer_email
+
+  const to = customerEmail
+    ? [customerEmail]
+    : splitIfString(data.to)
 
   emailEditorRef.value.addToReply(
     data.content,
-    splitIfString(data.to),
+    to,
     splitIfString(data.cc),
     splitIfString(data.bcc)
-  );
+  )
 }
 
 const props = defineProps({

--- a/desk/src/components/EmailArea.vue
+++ b/desk/src/components/EmailArea.vue
@@ -115,6 +115,10 @@ import { ReplyAllIcon, ReplyIcon } from "./icons";
 import TicketSplitModal from "./ticket/TicketSplitModal.vue";
 import { useAuthStore } from "@/stores/auth";
 import { storeToRefs } from "pinia";
+import { inject } from "vue"
+import { TicketSymbol } from "@/types"
+
+const ticket = inject(TicketSymbol)
 
 const props = defineProps({
   activity: {
@@ -165,10 +169,21 @@ const status = computed(() => {
 
 const reply = () => {
   const user = auth.user.value;
+
+  const recipient =
+    ticket?.value?.doc?.customer_email ||
+    (user === sender.name ? to : sender.name);
+
   emit("reply", {
     content: content,
-    to: user === sender.name ? to : sender.name,
+    to: recipient,
   });
+
+  // const user = auth.user.value;
+  // emit("reply", {
+  //   content: content,
+  //   to: user === sender.name ? to : sender.name,
+  // });
 };
 
 const replyAll = () => {

--- a/desk/src/components/ticket-agent/TicketActivityPanel.vue
+++ b/desk/src/components/ticket-agent/TicketActivityPanel.vue
@@ -36,7 +36,7 @@
   <CommunicationArea
     ref="communicationAreaRef"
     :ticketId="String(ticket.doc?.name)"
-    :to-emails="[ticket.doc?.raised_by]"
+    :to-emails="[ticket.doc?.customer_email || ticket.doc?.raised_by]"
     :cc-emails="[]"
     :bcc-emails="[]"
     :key="ticket.doc?.name"

--- a/desk/src/components/ticket-agent/TicketDetailsTab.vue
+++ b/desk/src/components/ticket-agent/TicketDetailsTab.vue
@@ -7,13 +7,55 @@
       <div>
         <div v-for="(section, index) in coreFields" :key="index" :class="section.group ? 'flex gap-2 items-center w-full mb-3' : 'mb-3'
           ">
-          <template v-for="field in section.fields">
+          <!-- <template v-for="field in section.fields">
             <Link v-if="field.visible" :key="field.fieldname" :ref="(el) => setFieldRef(field.fieldname, el)"
               class="form-control-core" :id="field.fieldname" :class="section.group ? 'flex-1' : 'w-full'"
-              :page-length="10" :label="field.label" :placeholder="field.placeholder" :doctype="field.doctype"
+              :page-length="10" :label="field.label" :placeholder="field.placeholder" :disabled="section.disabled" :doctype="field.doctype"
               :modelValue="field.value" :required="field.required" @update:model-value="
                 (val: string) => handleFieldUpdate(field.fieldname, val, true)
               " />
+          </template> -->
+
+          <template v-for="field in section.fields">
+            <!-- Link fields -->
+            <Link
+              v-if="field.visible && field.fieldtype === 'Link'"
+              :key="field.fieldname"
+              :ref="(el) => setFieldRef(field.fieldname, el)"
+              class="form-control-core"
+              :id="field.fieldname"
+              :class="section.group ? 'flex-1' : 'w-full'"
+              :page-length="10"
+              :label="field.label"
+              :placeholder="field.placeholder"
+              :disabled="section.disabled"
+              :doctype="field.doctype"
+              :modelValue="field.value"
+              :required="field.required"
+              @update:model-value="
+                (val: string) => handleFieldUpdate(field.fieldname, val, true)
+              "
+            />
+
+            <div
+              v-else-if="field.visible"
+              :key="field.fieldname"
+              :class="section.group ? 'flex-1' : 'w-full'"
+            >
+              <!-- Label -->
+              <label class="block text-xs text-ink-gray-5 mb-1">
+                {{ field.label }}
+              </label>
+
+              <!-- Fake Link field -->
+              <div class="form-control-core">
+                <button disabled>
+                  <div class="truncate">
+                    {{ field.value || field.placeholder }}
+                  </div>
+                </button>
+              </div>
+            </div>
           </template>
         </div>
 
@@ -69,10 +111,18 @@ const coreFields = computed(() => {
     return [];
   }
   const _coreFields = [
-    { group: true, fields: [getField("ticket_type"), getField("priority")] },
-    { group: false, fields: [getField("customer")] },
-    { group: true, fields: [getField("agent_group")] },
+    { group: true, fields: [getField("ticket_type"), getField("priority")], disabled: false },
+    { group: false, fields: [getField("customer")], disabled: false },
+    { group: true, fields: [getField("agent_group")], disabled: false },
   ];
+
+  if (ticket.value?.doc?.customer_email) {
+    _coreFields.splice(2, 0, {
+      group: false,
+      fields: [getField("customer_email")],
+      disabled: true,
+    });
+  }
 
   _coreFields.forEach((section) => {
     section.fields = section.fields.map((f) => {

--- a/desk/src/pages/ticket/TicketNew.vue
+++ b/desk/src/pages/ticket/TicketNew.vue
@@ -50,6 +50,16 @@
             :placeholder="__('A short description')"
           />
         </div>
+        <div class="flex flex-col gap-2 mt-5">
+                  <span class="block text-sm text-gray-700">
+                    {{ __("Customer Email") }}
+                  </span>
+                  <FormControl
+                    v-model="customerEmail"
+                    type="email"
+                    :placeholder="__('john@example.com')"
+                  />
+        </div>
         <SearchArticles
           v-if="isCustomerPortal"
           :query="subject"
@@ -158,6 +168,7 @@ const { updateOnboardingStep } = useOnboarding("helpdesk");
 const { isManager, userId: userID } = useAuthStore();
 
 const subject = ref("");
+const customerEmail = ref("");
 const description = ref("");
 const attachments = ref([]);
 const templateFields = reactive({});
@@ -227,6 +238,7 @@ const ticket = createResource({
     doc: {
       description: description.value,
       subject: subject.value,
+      customer_email: customerEmail.value,
       template: props.templateId,
       ...templateFields,
     },
@@ -260,6 +272,7 @@ const ticket = createResource({
           user: userID,
           ticketID: data.name,
           subject: subject.value,
+          customer_email: customerEmail.value,
           description: description.value,
           customFields: templateFields,
         },

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1,519 +1,528 @@
 {
- "actions": [],
- "allow_import": 1,
- "autoname": "autoincrement",
- "creation": "2023-10-17 14:27:11.078679",
- "doctype": "DocType",
- "document_type": "Setup",
- "email_append_to": 1,
- "engine": "InnoDB",
- "field_order": [
-  "subject_section",
-  "subject",
-  "raised_by",
-  "status",
-  "priority",
-  "status_category",
-  "cb00",
-  "ticket_type",
-  "agent_group",
-  "summary",
-  "sb_details",
-  "description",
-  "template",
-  "key",
-  "sla_tab",
-  "service_level_section",
-  "sla",
-  "response_by",
-  "cb",
-  "agreement_status",
-  "resolution_by",
-  "service_level_agreement_creation",
-  "on_hold_since",
-  "total_hold_time",
-  "response_tab",
-  "response",
-  "first_response_time",
-  "first_responded_on",
-  "column_break_26",
-  "avg_response_time",
-  "resolution_tab",
-  "section_break_19",
-  "resolution_details",
-  "column_break1",
-  "opening_date",
-  "opening_time",
-  "resolution_date",
-  "resolution_time",
-  "user_resolution_time",
-  "reference_tab",
-  "additional_info",
-  "contact",
-  "customer",
-  "email_account",
-  "column_break_16",
-  "via_customer_portal",
-  "attachment",
-  "content_type",
-  "split_and_merge_section",
-  "is_merged",
-  "merged_with",
-  "ticket_split_from",
-  "feedback_tab",
-  "customer_feedback_section",
-  "feedback_rating",
-  "feedback",
-  "feedback_extra",
-  "meta_tab"
- ],
- "fields": [
-  {
-   "fieldname": "subject_section",
-   "fieldtype": "Section Break",
-   "options": "fa fa-flag"
-  },
-  {
-   "bold": 1,
-   "fieldname": "subject",
-   "fieldtype": "Data",
-   "in_global_search": 1,
-   "in_standard_filter": 1,
-   "label": "Subject",
-   "reqd": 1
-  },
-  {
-   "bold": 1,
-   "depends_on": "eval:doc.__islocal",
-   "fieldname": "raised_by",
-   "fieldtype": "Data",
-   "in_global_search": 1,
-   "in_list_view": 1,
-   "label": "Raised By (Email)",
-   "oldfieldname": "raised_by",
-   "oldfieldtype": "Data",
-   "options": "Email"
-  },
-  {
-   "fieldname": "status",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Status",
-   "no_copy": 1,
-   "oldfieldname": "status",
-   "oldfieldtype": "Select",
-   "options": "HD Ticket Status",
-   "search_index": 1
-  },
-  {
-   "fieldname": "priority",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Priority",
-   "options": "HD Ticket Priority"
-  },
-  {
-   "fieldname": "cb00",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "ticket_type",
-   "fieldtype": "Link",
-   "label": "Ticket Type",
-   "options": "HD Ticket Type"
-  },
-  {
-   "fieldname": "agent_group",
-   "fieldtype": "Link",
-   "label": "Team",
-   "options": "HD Team"
-  },
-  {
-   "fieldname": "ticket_split_from",
-   "fieldtype": "Link",
-   "label": "Ticket Split From",
-   "options": "HD Ticket",
-   "read_only": 1
-  },
-  {
-   "collapsible": 1,
-   "collapsible_depends_on": "eval:doc.status!=\"Closed\"",
-   "fieldname": "sb_details",
-   "fieldtype": "Section Break",
-   "label": "Details"
-  },
-  {
-   "bold": 1,
-   "fieldname": "description",
-   "fieldtype": "Text Editor",
-   "in_global_search": 1,
-   "label": "Description",
-   "oldfieldname": "problem_description",
-   "oldfieldtype": "Text"
-  },
-  {
-   "fieldname": "template",
-   "fieldtype": "Link",
-   "label": "Template",
-   "options": "HD Ticket Template"
-  },
-  {
-   "collapsible": 1,
-   "fieldname": "service_level_section",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "sla",
-   "fieldtype": "Link",
-   "label": "SLA",
-   "options": "HD Service Level Agreement"
-  },
-  {
-   "depends_on": "eval: doc.status_category != 'Paused' && doc.sla;",
-   "fieldname": "response_by",
-   "fieldtype": "Datetime",
-   "label": "Response By",
-   "read_only": 1
-  },
-  {
-   "collapsible": 1,
-   "fieldname": "cb",
-   "fieldtype": "Column Break",
-   "options": "fa fa-pushpin",
-   "read_only": 1
-  },
-  {
-   "depends_on": "eval: doc.sla",
-   "fieldname": "agreement_status",
-   "fieldtype": "Select",
-   "label": "SLA Status",
-   "options": "\nFirst Response Due\nResolution Due\nFailed\nFulfilled\nPaused",
-   "read_only": 1
-  },
-  {
-   "depends_on": "eval: doc.status_category != 'Paused' && doc.sla;",
-   "fieldname": "resolution_by",
-   "fieldtype": "Datetime",
-   "label": "Resolution By",
-   "read_only": 1
-  },
-  {
-   "fieldname": "service_level_agreement_creation",
-   "fieldtype": "Datetime",
-   "hidden": 1,
-   "label": "SLA Creation",
-   "read_only": 1
-  },
-  {
-   "fieldname": "on_hold_since",
-   "fieldtype": "Datetime",
-   "label": "On Hold Since",
-   "read_only": 1
-  },
-  {
-   "fieldname": "total_hold_time",
-   "fieldtype": "Duration",
-   "label": "Total Hold Time",
-   "read_only": 1
-  },
-  {
-   "collapsible": 1,
-   "fieldname": "response",
-   "fieldtype": "Section Break"
-  },
-  {
-   "bold": 1,
-   "fieldname": "first_response_time",
-   "fieldtype": "Duration",
-   "label": "First Response Time",
-   "read_only": 1
-  },
-  {
-   "fieldname": "first_responded_on",
-   "fieldtype": "Datetime",
-   "label": "First Responded On"
-  },
-  {
-   "fieldname": "column_break_26",
-   "fieldtype": "Column Break"
-  },
-  {
-   "bold": 1,
-   "fieldname": "avg_response_time",
-   "fieldtype": "Duration",
-   "label": "Average Response Time",
-   "read_only": 1
-  },
-  {
-   "collapsible": 1,
-   "fieldname": "section_break_19",
-   "fieldtype": "Section Break"
-  },
-  {
-   "depends_on": "eval:!doc.__islocal",
-   "fieldname": "resolution_details",
-   "fieldtype": "Text Editor",
-   "label": "Resolution Details",
-   "no_copy": 1,
-   "oldfieldname": "resolution_details",
-   "oldfieldtype": "Text"
-  },
-  {
-   "depends_on": "eval:!doc.__islocal",
-   "fieldname": "column_break1",
-   "fieldtype": "Column Break",
-   "oldfieldtype": "Column Break",
-   "read_only": 1
-  },
-  {
-   "default": "Today",
-   "fieldname": "opening_date",
-   "fieldtype": "Date",
-   "label": "Opening Date",
-   "no_copy": 1,
-   "oldfieldname": "opening_date",
-   "oldfieldtype": "Date",
-   "read_only": 1
-  },
-  {
-   "fieldname": "opening_time",
-   "fieldtype": "Time",
-   "label": "Opening Time",
-   "no_copy": 1,
-   "oldfieldname": "opening_time",
-   "oldfieldtype": "Time",
-   "read_only": 1
-  },
-  {
-   "depends_on": "eval:!doc.__islocal",
-   "fieldname": "resolution_date",
-   "fieldtype": "Datetime",
-   "label": "Resolution Date",
-   "no_copy": 1,
-   "oldfieldname": "resolution_date",
-   "oldfieldtype": "Date",
-   "read_only": 1
-  },
-  {
-   "fieldname": "resolution_time",
-   "fieldtype": "Duration",
-   "label": "Resolution Time",
-   "read_only": 1
-  },
-  {
-   "fieldname": "user_resolution_time",
-   "fieldtype": "Duration",
-   "label": "User Resolution Time",
-   "read_only": 1
-  },
-  {
-   "collapsible": 1,
-   "fieldname": "additional_info",
-   "fieldtype": "Section Break",
-   "options": "fa fa-pushpin",
-   "read_only": 1
-  },
-  {
-   "fieldname": "contact",
-   "fieldtype": "Link",
-   "label": "Contact",
-   "options": "Contact"
-  },
-  {
-   "fieldname": "customer",
-   "fieldtype": "Link",
-   "in_standard_filter": 1,
-   "label": "Customer",
-   "options": "HD Customer"
-  },
-  {
-   "fieldname": "email_account",
-   "fieldtype": "Link",
-   "label": "Email Account",
-   "options": "Email Account"
-  },
-  {
-   "fieldname": "column_break_16",
-   "fieldtype": "Column Break"
-  },
-  {
-   "default": "0",
-   "fieldname": "via_customer_portal",
-   "fieldtype": "Check",
-   "label": "Via Customer Portal"
-  },
-  {
-   "fieldname": "attachment",
-   "fieldtype": "Attach",
-   "hidden": 1,
-   "label": "Attachment"
-  },
-  {
-   "fieldname": "content_type",
-   "fieldtype": "Data",
-   "hidden": 1,
-   "label": "Content Type"
-  },
-  {
-   "fieldname": "customer_feedback_section",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "feedback_extra",
-   "fieldtype": "Long Text",
-   "label": "Feedback (Extra)"
-  },
-  {
-   "fieldname": "feedback",
-   "fieldtype": "Link",
-   "label": "Feedback (Option)",
-   "options": "HD Ticket Feedback Option"
-  },
-  {
-   "fieldname": "feedback_rating",
-   "fieldtype": "Rating",
-   "label": "Rating"
-  },
-  {
-   "fieldname": "sla_tab",
-   "fieldtype": "Tab Break",
-   "label": "SLA"
-  },
-  {
-   "fieldname": "response_tab",
-   "fieldtype": "Tab Break",
-   "label": "Response"
-  },
-  {
-   "fieldname": "resolution_tab",
-   "fieldtype": "Tab Break",
-   "label": "Resolution"
-  },
-  {
-   "fieldname": "reference_tab",
-   "fieldtype": "Tab Break",
-   "label": "Reference"
-  },
-  {
-   "fieldname": "feedback_tab",
-   "fieldtype": "Tab Break",
-   "label": "Feedback"
-  },
-  {
-   "fieldname": "meta_tab",
-   "fieldtype": "Tab Break",
-   "label": "Meta"
-  },
-  {
-   "fieldname": "summary",
-   "fieldtype": "Text Editor",
-   "label": "Summary"
-  },
-  {
-   "fieldname": "split_and_merge_section",
-   "fieldtype": "Section Break",
-   "label": "Split and Merge"
-  },
-  {
-   "default": "0",
-   "fieldname": "is_merged",
-   "fieldtype": "Check",
-   "label": "Ticket Merged"
-  },
-  {
-   "depends_on": "eval:doc.is_merged",
-   "fieldname": "merged_with",
-   "fieldtype": "Link",
-   "label": "Merged With",
-   "options": "HD Ticket",
-   "read_only": 1
-  },
-  {
-   "fieldname": "key",
-   "fieldtype": "Data",
-   "label": "Key",
-   "read_only": 1,
-   "set_only_once": 1
-  },
-  {
-   "fetch_from": "status.category",
-   "fieldname": "status_category",
-   "fieldtype": "Data",
-   "label": "Status Category",
-   "read_only": 1
-  }
- ],
- "grid_page_length": 50,
- "icon": "fa fa-issue",
- "idx": 61,
- "links": [],
- "modified": "2025-10-26 17:07:55.243874",
- "modified_by": "Administrator",
- "module": "Helpdesk",
- "name": "HD Ticket",
- "naming_rule": "Autoincrement",
- "owner": "Administrator",
- "permissions": [
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "System Manager",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Agent",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "create": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "All",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Agent Manager",
-   "share": 1,
-   "write": 1
-  }
- ],
- "quick_entry": 1,
- "recipient_account_field": "email_account",
- "row_format": "Dynamic",
- "search_fields": "status,subject,raised_by",
- "sender_field": "raised_by",
- "show_title_field_in_link": 1,
- "sort_field": "modified",
- "sort_order": "DESC",
- "states": [],
- "subject_field": "subject",
- "timeline_field": "contact",
- "title_field": "subject",
- "track_changes": 1,
- "track_seen": 1
+  "actions": [],
+  "allow_import": 1,
+  "autoname": "autoincrement",
+  "creation": "2023-10-17 14:27:11.078679",
+  "doctype": "DocType",
+  "document_type": "Setup",
+  "email_append_to": 1,
+  "engine": "InnoDB",
+  "field_order": [
+    "subject_section",
+    "subject",
+    "customer_email",
+    "raised_by",
+    "status",
+    "priority",
+    "status_category",
+    "cb00",
+    "ticket_type",
+    "agent_group",
+    "summary",
+    "sb_details",
+    "description",
+    "template",
+    "key",
+    "sla_tab",
+    "service_level_section",
+    "sla",
+    "response_by",
+    "cb",
+    "agreement_status",
+    "resolution_by",
+    "service_level_agreement_creation",
+    "on_hold_since",
+    "total_hold_time",
+    "response_tab",
+    "response",
+    "first_response_time",
+    "first_responded_on",
+    "column_break_26",
+    "avg_response_time",
+    "resolution_tab",
+    "section_break_19",
+    "resolution_details",
+    "column_break1",
+    "opening_date",
+    "opening_time",
+    "resolution_date",
+    "resolution_time",
+    "user_resolution_time",
+    "reference_tab",
+    "additional_info",
+    "contact",
+    "customer",
+    "email_account",
+    "column_break_16",
+    "via_customer_portal",
+    "attachment",
+    "content_type",
+    "split_and_merge_section",
+    "is_merged",
+    "merged_with",
+    "ticket_split_from",
+    "feedback_tab",
+    "customer_feedback_section",
+    "feedback_rating",
+    "feedback",
+    "feedback_extra",
+    "meta_tab"
+  ],
+  "fields": [
+    {
+      "fieldname": "subject_section",
+      "fieldtype": "Section Break",
+      "options": "fa fa-flag"
+    },
+    {
+      "bold": 1,
+      "fieldname": "subject",
+      "fieldtype": "Data",
+      "in_global_search": 1,
+      "in_standard_filter": 1,
+      "label": "Subject",
+      "reqd": 1
+    },
+    {
+      "bold": 1,
+      "fieldname": "customer_email",
+      "fieldtype": "Data",
+      "in_global_search": 1,
+      "in_standard_filter": 1,
+      "label": "Customer Email"
+    },
+    {
+      "bold": 1,
+      "depends_on": "eval:doc.__islocal",
+      "fieldname": "raised_by",
+      "fieldtype": "Data",
+      "in_global_search": 1,
+      "in_list_view": 1,
+      "label": "Raised By (Email)",
+      "oldfieldname": "raised_by",
+      "oldfieldtype": "Data",
+      "options": "Email"
+    },
+    {
+      "fieldname": "status",
+      "fieldtype": "Link",
+      "in_list_view": 1,
+      "label": "Status",
+      "no_copy": 1,
+      "oldfieldname": "status",
+      "oldfieldtype": "Select",
+      "options": "HD Ticket Status",
+      "search_index": 1
+    },
+    {
+      "fieldname": "priority",
+      "fieldtype": "Link",
+      "in_list_view": 1,
+      "label": "Priority",
+      "options": "HD Ticket Priority"
+    },
+    {
+      "fieldname": "cb00",
+      "fieldtype": "Column Break"
+    },
+    {
+      "fieldname": "ticket_type",
+      "fieldtype": "Link",
+      "label": "Ticket Type",
+      "options": "HD Ticket Type"
+    },
+    {
+      "fieldname": "agent_group",
+      "fieldtype": "Link",
+      "label": "Team",
+      "options": "HD Team"
+    },
+    {
+      "fieldname": "ticket_split_from",
+      "fieldtype": "Link",
+      "label": "Ticket Split From",
+      "options": "HD Ticket",
+      "read_only": 1
+    },
+    {
+      "collapsible": 1,
+      "collapsible_depends_on": "eval:doc.status!=\"Closed\"",
+      "fieldname": "sb_details",
+      "fieldtype": "Section Break",
+      "label": "Details"
+    },
+    {
+      "bold": 1,
+      "fieldname": "description",
+      "fieldtype": "Text Editor",
+      "in_global_search": 1,
+      "label": "Description",
+      "oldfieldname": "problem_description",
+      "oldfieldtype": "Text"
+    },
+    {
+      "fieldname": "template",
+      "fieldtype": "Link",
+      "label": "Template",
+      "options": "HD Ticket Template"
+    },
+    {
+      "collapsible": 1,
+      "fieldname": "service_level_section",
+      "fieldtype": "Section Break"
+    },
+    {
+      "fieldname": "sla",
+      "fieldtype": "Link",
+      "label": "SLA",
+      "options": "HD Service Level Agreement"
+    },
+    {
+      "depends_on": "eval: doc.status_category != 'Paused' && doc.sla;",
+      "fieldname": "response_by",
+      "fieldtype": "Datetime",
+      "label": "Response By",
+      "read_only": 1
+    },
+    {
+      "collapsible": 1,
+      "fieldname": "cb",
+      "fieldtype": "Column Break",
+      "options": "fa fa-pushpin",
+      "read_only": 1
+    },
+    {
+      "depends_on": "eval: doc.sla",
+      "fieldname": "agreement_status",
+      "fieldtype": "Select",
+      "label": "SLA Status",
+      "options": "\nFirst Response Due\nResolution Due\nFailed\nFulfilled\nPaused",
+      "read_only": 1
+    },
+    {
+      "depends_on": "eval: doc.status_category != 'Paused' && doc.sla;",
+      "fieldname": "resolution_by",
+      "fieldtype": "Datetime",
+      "label": "Resolution By",
+      "read_only": 1
+    },
+    {
+      "fieldname": "service_level_agreement_creation",
+      "fieldtype": "Datetime",
+      "hidden": 1,
+      "label": "SLA Creation",
+      "read_only": 1
+    },
+    {
+      "fieldname": "on_hold_since",
+      "fieldtype": "Datetime",
+      "label": "On Hold Since",
+      "read_only": 1
+    },
+    {
+      "fieldname": "total_hold_time",
+      "fieldtype": "Duration",
+      "label": "Total Hold Time",
+      "read_only": 1
+    },
+    {
+      "collapsible": 1,
+      "fieldname": "response",
+      "fieldtype": "Section Break"
+    },
+    {
+      "bold": 1,
+      "fieldname": "first_response_time",
+      "fieldtype": "Duration",
+      "label": "First Response Time",
+      "read_only": 1
+    },
+    {
+      "fieldname": "first_responded_on",
+      "fieldtype": "Datetime",
+      "label": "First Responded On"
+    },
+    {
+      "fieldname": "column_break_26",
+      "fieldtype": "Column Break"
+    },
+    {
+      "bold": 1,
+      "fieldname": "avg_response_time",
+      "fieldtype": "Duration",
+      "label": "Average Response Time",
+      "read_only": 1
+    },
+    {
+      "collapsible": 1,
+      "fieldname": "section_break_19",
+      "fieldtype": "Section Break"
+    },
+    {
+      "depends_on": "eval:!doc.__islocal",
+      "fieldname": "resolution_details",
+      "fieldtype": "Text Editor",
+      "label": "Resolution Details",
+      "no_copy": 1,
+      "oldfieldname": "resolution_details",
+      "oldfieldtype": "Text"
+    },
+    {
+      "depends_on": "eval:!doc.__islocal",
+      "fieldname": "column_break1",
+      "fieldtype": "Column Break",
+      "oldfieldtype": "Column Break",
+      "read_only": 1
+    },
+    {
+      "default": "Today",
+      "fieldname": "opening_date",
+      "fieldtype": "Date",
+      "label": "Opening Date",
+      "no_copy": 1,
+      "oldfieldname": "opening_date",
+      "oldfieldtype": "Date",
+      "read_only": 1
+    },
+    {
+      "fieldname": "opening_time",
+      "fieldtype": "Time",
+      "label": "Opening Time",
+      "no_copy": 1,
+      "oldfieldname": "opening_time",
+      "oldfieldtype": "Time",
+      "read_only": 1
+    },
+    {
+      "depends_on": "eval:!doc.__islocal",
+      "fieldname": "resolution_date",
+      "fieldtype": "Datetime",
+      "label": "Resolution Date",
+      "no_copy": 1,
+      "oldfieldname": "resolution_date",
+      "oldfieldtype": "Date",
+      "read_only": 1
+    },
+    {
+      "fieldname": "resolution_time",
+      "fieldtype": "Duration",
+      "label": "Resolution Time",
+      "read_only": 1
+    },
+    {
+      "fieldname": "user_resolution_time",
+      "fieldtype": "Duration",
+      "label": "User Resolution Time",
+      "read_only": 1
+    },
+    {
+      "collapsible": 1,
+      "fieldname": "additional_info",
+      "fieldtype": "Section Break",
+      "options": "fa fa-pushpin",
+      "read_only": 1
+    },
+    {
+      "fieldname": "contact",
+      "fieldtype": "Link",
+      "label": "Contact",
+      "options": "Contact"
+    },
+    {
+      "fieldname": "customer",
+      "fieldtype": "Link",
+      "in_standard_filter": 1,
+      "label": "Customer",
+      "options": "HD Customer"
+    },
+    {
+      "fieldname": "email_account",
+      "fieldtype": "Link",
+      "label": "Email Account",
+      "options": "Email Account"
+    },
+    {
+      "fieldname": "column_break_16",
+      "fieldtype": "Column Break"
+    },
+    {
+      "default": "0",
+      "fieldname": "via_customer_portal",
+      "fieldtype": "Check",
+      "label": "Via Customer Portal"
+    },
+    {
+      "fieldname": "attachment",
+      "fieldtype": "Attach",
+      "hidden": 1,
+      "label": "Attachment"
+    },
+    {
+      "fieldname": "content_type",
+      "fieldtype": "Data",
+      "hidden": 1,
+      "label": "Content Type"
+    },
+    {
+      "fieldname": "customer_feedback_section",
+      "fieldtype": "Section Break"
+    },
+    {
+      "fieldname": "feedback_extra",
+      "fieldtype": "Long Text",
+      "label": "Feedback (Extra)"
+    },
+    {
+      "fieldname": "feedback",
+      "fieldtype": "Link",
+      "label": "Feedback (Option)",
+      "options": "HD Ticket Feedback Option"
+    },
+    {
+      "fieldname": "feedback_rating",
+      "fieldtype": "Rating",
+      "label": "Rating"
+    },
+    {
+      "fieldname": "sla_tab",
+      "fieldtype": "Tab Break",
+      "label": "SLA"
+    },
+    {
+      "fieldname": "response_tab",
+      "fieldtype": "Tab Break",
+      "label": "Response"
+    },
+    {
+      "fieldname": "resolution_tab",
+      "fieldtype": "Tab Break",
+      "label": "Resolution"
+    },
+    {
+      "fieldname": "reference_tab",
+      "fieldtype": "Tab Break",
+      "label": "Reference"
+    },
+    {
+      "fieldname": "feedback_tab",
+      "fieldtype": "Tab Break",
+      "label": "Feedback"
+    },
+    {
+      "fieldname": "meta_tab",
+      "fieldtype": "Tab Break",
+      "label": "Meta"
+    },
+    {
+      "fieldname": "summary",
+      "fieldtype": "Text Editor",
+      "label": "Summary"
+    },
+    {
+      "fieldname": "split_and_merge_section",
+      "fieldtype": "Section Break",
+      "label": "Split and Merge"
+    },
+    {
+      "default": "0",
+      "fieldname": "is_merged",
+      "fieldtype": "Check",
+      "label": "Ticket Merged"
+    },
+    {
+      "depends_on": "eval:doc.is_merged",
+      "fieldname": "merged_with",
+      "fieldtype": "Link",
+      "label": "Merged With",
+      "options": "HD Ticket",
+      "read_only": 1
+    },
+    {
+      "fieldname": "key",
+      "fieldtype": "Data",
+      "label": "Key",
+      "read_only": 1,
+      "set_only_once": 1
+    },
+    {
+      "fetch_from": "status.category",
+      "fieldname": "status_category",
+      "fieldtype": "Data",
+      "label": "Status Category",
+      "read_only": 1
+    }
+  ],
+  "grid_page_length": 50,
+  "icon": "fa fa-issue",
+  "idx": 61,
+  "links": [],
+  "modified": "2025-10-26 17:07:55.243874",
+  "modified_by": "Administrator",
+  "module": "Helpdesk",
+  "name": "HD Ticket",
+  "naming_rule": "Autoincrement",
+  "owner": "Administrator",
+  "permissions": [
+    {
+      "create": 1,
+      "delete": 1,
+      "email": 1,
+      "export": 1,
+      "print": 1,
+      "read": 1,
+      "report": 1,
+      "role": "System Manager",
+      "share": 1,
+      "write": 1
+    },
+    {
+      "create": 1,
+      "delete": 1,
+      "email": 1,
+      "export": 1,
+      "print": 1,
+      "read": 1,
+      "report": 1,
+      "role": "Agent",
+      "share": 1,
+      "write": 1
+    },
+    {
+      "create": 1,
+      "email": 1,
+      "export": 1,
+      "print": 1,
+      "read": 1,
+      "report": 1,
+      "role": "All",
+      "share": 1,
+      "write": 1
+    },
+    {
+      "create": 1,
+      "delete": 1,
+      "email": 1,
+      "export": 1,
+      "print": 1,
+      "read": 1,
+      "report": 1,
+      "role": "Agent Manager",
+      "share": 1,
+      "write": 1
+    }
+  ],
+  "quick_entry": 1,
+  "recipient_account_field": "email_account",
+  "row_format": "Dynamic",
+  "search_fields": "status,subject,raised_by",
+  "sender_field": "raised_by",
+  "show_title_field_in_link": 1,
+  "sort_field": "modified",
+  "sort_order": "DESC",
+  "states": [],
+  "subject_field": "subject",
+  "timeline_field": "contact",
+  "title_field": "subject",
+  "track_changes": 1,
+  "track_seen": 1
 }


### PR DESCRIPTION
## Summary

This PR adds customer email field. And makes sure that if a customer email is set the reply are automatically sent to it.

When testing don't forget to do a migration since the Doc Type is changed

## Changes

- Edit hd_ticket.py ("HD Ticket") doc type to support customer email filed
- Edit TicketNew.vue to support customer email field
- Edit TicketDetailsTab.vue to show the customer email if one is set
- Edit EmailArea.vue to automatically select customer email if one is set
 
## Screenshots
<img width="899" height="367" alt="{2E6A0EFB-1BF6-4244-AE51-23CD7D8EC59D}" src="https://github.com/user-attachments/assets/80098b24-0b4f-4be2-b767-c95925d0db3b" />

<img width="352" height="451" alt="{C56FAFF8-2949-4F93-8D1A-59F0F81A3B2B}" src="https://github.com/user-attachments/assets/e5046564-a9b9-4c8e-8ebe-9f2b728da87c" />
