### PR TITLE
Add update for the unread notification indicator & add diffrent indicator for unassigned tickets

### DIFF
--- a/desk/src/pages/ticket/Tickets.vue
+++ b/desk/src/pages/ticket/Tickets.vue
@@ -117,6 +117,29 @@ const options = {
     subject: {
       custom: ({ row, item }) => {
         const unread = !row.read;
+        console.log(row._assign)
+
+        if (row._assign === null) {
+          return h(
+            "div",
+            { class: "flex items-center gap-2 w-full" },
+            [
+                h("span", {
+                  class: "w-2 h-2 rounded-full bg-red-500 shrink-0",
+                }),
+
+              h(
+                "span",
+                {
+                  class: row._assign === null
+                    ? "font-semibold truncate flex-1"
+                    : "truncate flex-1",
+                },
+                item
+              ),
+            ]
+          );
+        }
 
         return h(
           "div",

--- a/desk/src/pages/ticket/Tickets.vue
+++ b/desk/src/pages/ticket/Tickets.vue
@@ -117,7 +117,6 @@ const options = {
     subject: {
       custom: ({ row, item }) => {
         const unread = !row.read;
-        console.log(row._assign)
 
         return h(
           "div",

--- a/desk/src/pages/ticket/Tickets.vue
+++ b/desk/src/pages/ticket/Tickets.vue
@@ -598,7 +598,6 @@ onMounted(() => {
 onUnmounted(() => {
   if (!isCustomerPortal.value) {
     $socket.off("helpdesk:new-ticket");
-    $socket.off("helpdesk:new_message");
   }
 });
 

--- a/desk/src/pages/ticket/Tickets.vue
+++ b/desk/src/pages/ticket/Tickets.vue
@@ -119,41 +119,19 @@ const options = {
         const unread = !row.read;
         console.log(row._assign)
 
-        if (row._assign === null) {
-          return h(
-            "div",
-            { class: "flex items-center gap-2 w-full" },
-            [
-                h("span", {
-                  class: "w-2 h-2 rounded-full bg-red-500 shrink-0",
-                }),
-
-              h(
-                "span",
-                {
-                  class: row._assign === null
-                    ? "font-semibold truncate flex-1"
-                    : "truncate flex-1",
-                },
-                item
-              ),
-            ]
-          );
-        }
-
         return h(
           "div",
           { class: "flex items-center gap-2 w-full" },
           [
-            unread &&
+            (unread || row._assign === null) &&
               h("span", {
-                class: "w-2 h-2 rounded-full bg-blue-500 shrink-0",
+                class: `w-2 h-2 rounded-full ${unread? "bg-blue-500": "bg-red-500"} shrink-0`,
               }),
 
             h(
               "span",
               {
-                class: unread
+                class: (unread || row._assign === null)
                   ? "font-semibold truncate flex-1"
                   : "truncate flex-1",
               },

--- a/desk/src/pages/ticket/Tickets.vue
+++ b/desk/src/pages/ticket/Tickets.vue
@@ -600,22 +600,28 @@ function resetState() {
 }
 
 onMounted(() => {
-  if (!route.query.view) {
-    currentView.value = {
-      label: __("List"),
-      icon: LucideAlignJustify,
-    };
-  }
-  if (!isCustomerPortal.value) {
-    $socket.on("helpdesk:new-ticket", () => {
-      listViewRef.value?.reload();
-    });
-  }
+    if (!route.query.view) {
+      currentView.value = {
+        label: __("List"),
+        icon: LucideAlignJustify,
+      };
+    }
+
+    if (!isCustomerPortal.value) {
+      $socket.on("helpdesk:new-ticket", () => {
+        listViewRef.value?.reload();
+      });
+
+      $socket.on("helpdesk:new_message", () => {
+        listViewRef.value?.reload();
+      });
+    }
 });
 
 onUnmounted(() => {
   if (!isCustomerPortal.value) {
     $socket.off("helpdesk:new-ticket");
+    $socket.off("helpdesk:new_message");
   }
 });
 


### PR DESCRIPTION
## Summary

This PR adds live reload for the unread notifications using socket and implement new UI element that represents unassigned ticket

## Changes

- Edit Tickets.vue to check if somebody is assigned and if not render the correct UI element
- Edit Ticket.vue to listen for a call on the helpdesk:new_message socket and if there is one to refetch the tickets

## Screenshots
<img width="1436" height="49" alt="{0E757A3E-68E6-4B8B-B7DF-CDE7DADFBB73}" src="https://github.com/user-attachments/assets/acdde0e4-2474-4e27-9eb6-772bdcfe8b1f" />
